### PR TITLE
Remove uses of Thread.Abort

### DIFF
--- a/Duplicati/Library/Utility/AsyncExtensions.cs
+++ b/Duplicati/Library/Utility/AsyncExtensions.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Duplicati.Library.Utility
+{
+    /// <summary>
+    /// Extension methods to provide additional Async/Await functionality for various objects.
+    /// </summary>
+    public static class AsyncExtensions
+    {
+        /// <summary>
+        /// Allows asynchronously waiting on a WaitHandle with an optional delay
+        /// </summary>
+        /// <param name="waitHandle">The handle to wait on.</param>
+        /// <param name="delay">The duration to wait for the handled to be signaled.  If null is provided then the timeout never elapses.</param>
+        /// <returns>A task that completes when the WaitHandle is signaled or the delay elapses.</returns>
+        /// <remarks>
+        /// Modified slightly from the MSDN documentation on handled WaitHandles in async code.
+        /// https://docs.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/interop-with-other-asynchronous-patterns-and-types#from-wait-handles-to-tap
+        /// </remarks>
+        public static Task WaitOneAsync(this WaitHandle waitHandle, TimeSpan? delay = null)
+        {
+            if (waitHandle == null)
+                throw new ArgumentNullException("waitHandle");
+
+            var tcs = new TaskCompletionSource<bool>();
+            var rwh = ThreadPool.RegisterWaitForSingleObject(waitHandle,
+                delegate { tcs.TrySetResult(true); }, null, delay ?? Timeout.InfiniteTimeSpan, true);
+            var t = tcs.Task;
+            t.ContinueWith((antecedent) => rwh.Unregister(null));
+            return t;
+        }
+
+        /// <summary>
+        /// Allows asynchronously waiting on for a CancellationToken to be cancelled.
+        /// </summary>
+        /// <param name="cancellationToken">The token to wait on.</param>
+        /// <param name="delay">The duration to wait for cancellation for.  If 0 is provided, then the cancellation token will be checked and 
+        /// immediately return.  If null is provided then the timout never elapses.</param>
+        /// <returns>A task that completes when the cancellation token is cancelled or the delay elapses.</returns>
+        public static async Task WhenCancelled(this CancellationToken cancellationToken, TimeSpan? delay = null)
+        {
+            if (cancellationToken == CancellationToken.None)
+            {
+                throw new InvalidOperationException("CancellationToken.None will never be cancelled");
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            int delayMs= (int?)delay?.TotalMilliseconds ?? Timeout.Infinite;
+            if(delayMs == 0)
+            {
+                return;
+            }
+
+            TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
+            using (cancellationToken.Register(() => tcs.TrySetResult(true)))
+            {
+                if (delayMs == Timeout.Infinite)
+                {
+                    await tcs.Task;
+                }
+                else
+                {
+                    await Task.WhenAny(tcs.Task, Task.Delay(delayMs));
+                }
+            }
+        }
+    }
+}

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -425,8 +425,6 @@ namespace Duplicati.Library.Utility
             return parent;
         }
 
-        
-
         /// <summary>
         /// Given a collection of unique folders, returns only parent-most folders
         /// </summary>
@@ -471,7 +469,7 @@ namespace Duplicati.Library.Utility
 
             return result.Distinct();
         }
-        
+
         /// <summary>
         /// Given a collection of file paths, return those NOT contained within specified collection of folders
         /// </summary>

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -719,15 +719,13 @@ namespace Duplicati.Server
                 case LiveControls.LiveControlState.Paused:
                     {
                         WorkThread.Pause();
-                        var t = WorkThread.CurrentTask;
-                        t?.Pause();
+                        WorkThread.CurrentTask?.Pause();
                         break;
                     }
                 case LiveControls.LiveControlState.Running:
                     {
                         WorkThread.Resume();
-                        var t = WorkThread.CurrentTask;
-                        t?.Resume();
+                        WorkThread.CurrentTask?.Resume();
                         break;
                     }
             }

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -46,8 +46,8 @@ namespace Duplicati.Server
             public IDictionary<string, string> ExtraOptions { get; internal set; }
             public string[] FilterStrings { get; internal set; }
 
-            public string BackupID { get { return Backup.ID; } }
-            public long TaskID { get { return m_taskID; } }
+            public string BackupID => Backup.ID;
+            public long TaskID { get; }
 
             internal Duplicati.Library.Main.Controller Controller { get; set; }
 
@@ -65,23 +65,17 @@ namespace Duplicati.Server
 
             public void Abort()
             {
-                var c = Controller;
-                if (c != null)
-                    c.Abort();
+                Controller?.Abort();
             }
 
             public void Pause()
             {
-                var c = Controller;
-                if (c != null)
-                    c.Pause();
+                Controller?.Pause();
             }
 
             public void Resume()
             {
-                var c = Controller;
-                if (c != null)
-                    c.Resume();
+                Controller?.Resume();
             }
 
             public long OriginalUploadSpeed { get; set; }
@@ -126,11 +120,9 @@ namespace Duplicati.Server
                 controller.MaxDownloadSpeed = download_throttle;
             }
 
-            private readonly long m_taskID;
-
             public RunnerData()
             {
-                m_taskID = System.Threading.Interlocked.Increment(ref RunnerTaskID);
+                TaskID = System.Threading.Interlocked.Increment(ref RunnerTaskID);
             }
         }
 
@@ -489,7 +481,7 @@ namespace Duplicati.Server
                     }
                     catch { }
 
-                    ((RunnerData)data).Controller = controller;
+                    data.SetController(controller);
                     data.UpdateThrottleSpeed();
 
                     if (backup.Metadata.ContainsKey("LastCompactFinished"))
@@ -631,7 +623,7 @@ namespace Duplicati.Server
             }
             finally
             {
-                ((RunnerData)data).Controller = null;
+                data.SetController(null);
             }
         }
 

--- a/Duplicati/Server/WebServer/RESTMethods/Backup.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backup.cs
@@ -661,8 +661,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                         for(int i = 0; i < 10; i++)
                             if (Program.WorkThread.Active)
                             {
-                                var t = Program.WorkThread.CurrentTask;
-                                if (backup.Equals(t == null ? null : t.Backup))
+                                if (backup == Program.WorkThread.CurrentTask?.Backup)
                                     System.Threading.Thread.Sleep(1000);
                                 else
                                     break;
@@ -672,8 +671,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
                         if (Program.WorkThread.Active)
                         {
-                            var t = Program.WorkThread.CurrentTask;
-                            if (backup.Equals(t == null ? null : t.Backup))
+                            if (backup == Program.WorkThread.CurrentTask?.Backup)
                             {
                                 if (hasPaused)
                                     Program.LiveControl.Resume();


### PR DESCRIPTION
Update most "runner" classes to use async tasks and cancellation tokens
to gracefully abort instead of depending on Thread.Abort() was is not
supported on pure .NET Core platforms.

Currently Controller.cs is still missing some functionality.  I'm not
familiar with how CoCoL handles creating tasks, so it's not clear to me
how the tasks created by that controller are managed, but right now that
means that there's currently no way to abort the controller tasks.
Suggestions on where to create or pass in a cancellation token would
be appreciated.