### PR TITLE
Remove all uses of HashAlgorithm.Create

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/Recompress.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Recompress.cs
@@ -208,7 +208,7 @@ namespace Duplicati.CommandLine.RecoveryTool
                                             textJSON = sourceStreamReader.ReadToEnd();
                                             JToken token = JObject.Parse(textJSON);
                                             var fileInfoBlocks = new FileInfo(Path.Combine(targetfolder, cmfileNew.Replace("vol/", "")));
-                                            var filehasher = HashAlgorithm.Create(m_Options.FileHashAlgorithm);
+                                            var filehasher = (HashAlgorithm)CryptoConfig.CreateFromName(m_Options.FileHashAlgorithm);
 
                                             using (var fileStream = fileInfoBlocks.Open(FileMode.Open))
                                             {

--- a/Duplicati/CommandLine/RecoveryTool/Restore.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Restore.cs
@@ -94,8 +94,8 @@ namespace Duplicati.CommandLine.RecoveryTool
                 return 100;
             }
 
-            var blockhasher = string.IsNullOrWhiteSpace(blockhash_str) ? null : HashAlgorithm.Create(blockhash_str);
-            var filehasher = string.IsNullOrWhiteSpace(filehash_str) ? null : HashAlgorithm.Create(filehash_str);
+            var blockhasher = string.IsNullOrWhiteSpace(blockhash_str) ? null : (HashAlgorithm)CryptoConfig.CreateFromName(blockhash_str);
+            var filehasher = string.IsNullOrWhiteSpace(filehash_str) ? null : (HashAlgorithm)CryptoConfig.CreateFromName(filehash_str);
 
             if (blockhasher == null)
                 throw new Duplicati.Library.Interface.UserInformationException(string.Format("Block hash algorithm not valid: {0}", blockhash_str), "BlockHashAlgorithmNotSupported");

--- a/Duplicati/Library/Backend/Backblaze/B2.cs
+++ b/Duplicati/Library/Backend/Backblaze/B2.cs
@@ -209,7 +209,7 @@ namespace Duplicati.Library.Backend.Backblaze
                 var p = measure.Position;
 
                 // Compute the hash
-                using(var hashalg = HashAlgorithm.Create("sha1"))
+                using(var hashalg = SHA1.Create())
                     sha1 = Library.Utility.Utility.ByteArrayAsHexString(hashalg.ComputeHash(measure));
 
                 measure.Position = p;
@@ -219,7 +219,7 @@ namespace Duplicati.Library.Backend.Backblaze
                 // No seeking possible, use a temp file
                 tmp = new TempFile();
                 using(var sr = System.IO.File.OpenWrite(tmp))
-                using(var hc = new HashCalculatingStream(measure, "sha1"))
+                using(var hc = new HashCalculatingStream(measure, SHA1.Create()))
                 {
                     await Utility.Utility.CopyStreamAsync(hc, sr, cancelToken).ConfigureAwait(false);
                     sha1 = hc.GetFinalHashString();

--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -20,8 +20,6 @@ namespace Duplicati.Library.Main
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<BackendManager>();
 
-        public const string VOLUME_HASH = "SHA256";
-
         /// <summary>
         /// Class to represent hash failures
         /// </summary>
@@ -415,14 +413,14 @@ namespace Duplicati.Library.Main
         public static string CalculateFileHash(string filename)
         {
             using (System.IO.FileStream fs = System.IO.File.OpenRead(filename))
-            using (var hasher = HashAlgorithm.Create(VOLUME_HASH))
+            using (var hasher = SHA256.Create())
                 return Convert.ToBase64String(hasher.ComputeHash(fs));
         }
 
         /// <summary> Calculate file hash directly on stream object (for piping) </summary>
         public static string CalculateFileHash(System.IO.Stream stream)
         {
-            using (var hasher = HashAlgorithm.Create(VOLUME_HASH))
+            using (var hasher = SHA256.Create())
                 return Convert.ToBase64String(hasher.ComputeHash(stream));
         }
 
@@ -433,7 +431,7 @@ namespace Duplicati.Library.Main
         public static System.Security.Cryptography.CryptoStream GetFileHasherStream
             (System.IO.Stream stream, System.Security.Cryptography.CryptoStreamMode mode, out Func<string> getHash)
         {
-            var hasher = HashAlgorithm.Create(VOLUME_HASH);
+            var hasher = SHA256Managed.Create();
             System.Security.Cryptography.CryptoStream retHasherStream =
                 new System.Security.Cryptography.CryptoStream(stream, hasher, mode);
             getHash = () =>
@@ -657,9 +655,9 @@ namespace Duplicati.Library.Main
                     item.IndexfileUpdated = true;
                 }
 
-                var hashsize = HashAlgorithm.Create(m_options.BlockHashAlgorithm).HashSize / 8;
                 using (IndexVolumeWriter wr = new IndexVolumeWriter(m_options))
                 {
+                    var hashsize = ((HashAlgorithm)CryptoConfig.CreateFromName(m_options.BlockHashAlgorithm)).HashSize / 8;
                     using (var rd = new IndexVolumeReader(p.CompressionModule, item.Indexfile.Item2.LocalFilename, m_options, hashsize))
                         wr.CopyFrom(rd, x => x == oldname ? newname : x);
                     item.Indexfile.Item1.Dispose();

--- a/Duplicati/Library/Main/Database/LocalRepairDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRepairDatabase.cs
@@ -340,7 +340,7 @@ namespace Duplicati.Library.Main.Database
 
         public void FixMissingBlocklistHashes(string blockhashalgorithm, long blocksize)
         {
-            var blockhasher = HashAlgorithm.Create(blockhashalgorithm);
+            var blockhasher = (HashAlgorithm)CryptoConfig.CreateFromName(blockhashalgorithm);
             var hashsize = blockhasher.HashSize / 8;
             var blocklistbuffer = new byte[blocksize];
             int blocklistoffset = 0;

--- a/Duplicati/Library/Main/Operation/Backup/StreamBlockSplitter.cs
+++ b/Duplicati/Library/Main/Operation/Backup/StreamBlockSplitter.cs
@@ -48,8 +48,8 @@ namespace Duplicati.Library.Main.Operation.Backup
             async self =>
             {
                 var blocksize = options.Blocksize;
-                var filehasher = HashAlgorithm.Create(options.FileHashAlgorithm);
-                var blockhasher = HashAlgorithm.Create(options.BlockHashAlgorithm);
+                var filehasher = (HashAlgorithm)CryptoConfig.CreateFromName(options.FileHashAlgorithm);
+                var blockhasher = (HashAlgorithm)CryptoConfig.CreateFromName(options.BlockHashAlgorithm);
                 var emptymetadata = Utility.WrapMetadata(new Dictionary<string, string>(), options);
                 var maxmetadatasize = (options.Blocksize / (long)options.BlockhashSize) * options.Blocksize;
 

--- a/Duplicati/Library/Main/Operation/Common/BackendHandler.cs
+++ b/Duplicati/Library/Main/Operation/Common/BackendHandler.cs
@@ -130,7 +130,7 @@ namespace Duplicati.Library.Main.Operation.Common
             public static string CalculateFileHash(string filename)
             {
                 using (System.IO.FileStream fs = System.IO.File.OpenRead(filename))
-                using (var hasher = HashAlgorithm.Create(VOLUME_HASH))
+                using (var hasher = SHA256.Create())
                     return Convert.ToBase64String(hasher.ComputeHash(fs));
             }
 

--- a/Duplicati/Library/Main/Operation/Common/IndexVolumeCreator.cs
+++ b/Duplicati/Library/Main/Operation/Common/IndexVolumeCreator.cs
@@ -135,7 +135,7 @@ namespace Duplicati.Library.Main.Operation.Common
     {
         public static async Task<IndexVolumeWriter> CreateIndexVolume(string blockname, Options options, Common.DatabaseCommon database)
         {
-            using(var h = HashAlgorithm.Create(options.BlockHashAlgorithm))
+            using(var h = (HashAlgorithm)CryptoConfig.CreateFromName(options.BlockHashAlgorithm))
             {
                 var w = new IndexVolumeWriter(options);
                 w.VolumeID = await database.RegisterRemoteVolumeAsync(w.RemoteFilename, RemoteVolumeType.Index, RemoteVolumeState.Temporary);
@@ -168,7 +168,7 @@ namespace Duplicati.Library.Main.Operation.Common
 
         /*public static async Task<IndexVolumeWriter> ReCreateIndexVolume(string selfname, Options options, Repair.RepairDatabase database)
         {
-            using(var h = System.Security.Cryptography.HashAlgorithm.Create(options.BlockHashAlgorithm))
+            using(var h = System.Security.Cryptography.(HashAlgorithm)CryptoConfig.CreateFromName(options.BlockHashAlgorithm))
             {
                 var w = new IndexVolumeWriter(options);
                 w.SetRemoteFilename(selfname);

--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -324,7 +324,7 @@ namespace Duplicati.Library.Main.Operation
             
                 if (!m_options.RepairOnlyPaths)
                 {
-                    var hashalg = HashAlgorithm.Create(m_options.BlockHashAlgorithm);
+                    var hashalg = (HashAlgorithm)CryptoConfig.CreateFromName(m_options.BlockHashAlgorithm);
                     if (hashalg == null)
                         throw new UserInformationException(Strings.Common.InvalidHashAlgorithm(m_options.BlockHashAlgorithm), "BlockHashAlgorithmNotSupported");
                     var hashsize = hashalg.HashSize / 8;

--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -118,7 +118,7 @@ namespace Duplicati.Library.Main.Operation
 
                 var tp = FilelistProcessor.RemoteListAnalysis(backend, m_options, db, m_result.BackendWriter, null);
                 var buffer = new byte[m_options.Blocksize];
-                var blockhasher = HashAlgorithm.Create(m_options.BlockHashAlgorithm);
+                var blockhasher = (HashAlgorithm)CryptoConfig.CreateFromName(m_options.BlockHashAlgorithm);
                 var hashsize = blockhasher.HashSize / 8;
 
                 if (blockhasher == null)
@@ -315,7 +315,7 @@ namespace Duplicati.Library.Main.Operation
                                     newEntry = w;
                                     w.SetRemoteFilename(n.Name);
 
-                                    var h = HashAlgorithm.Create(m_options.BlockHashAlgorithm);
+                                    var h = (HashAlgorithm)CryptoConfig.CreateFromName(m_options.BlockHashAlgorithm);
 
                                     foreach (var blockvolume in db.GetBlockVolumesFromIndexName(n.Name))
                                     {

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -161,7 +161,7 @@ namespace Duplicati.Library.Main.Operation
             var blocksize = options.Blocksize;
             var updateCounter = 0L;
             var fullblockverification = options.FullBlockVerification;
-            var blockhasher = fullblockverification ? HashAlgorithm.Create(options.BlockHashAlgorithm) : null;
+            var blockhasher = fullblockverification ? (HashAlgorithm)CryptoConfig.CreateFromName(options.BlockHashAlgorithm) : null;
 
             using (var blockmarker = database.CreateBlockMarker())
             using(var volumekeeper = database.GetMissingBlockData(blocks, options.Blocksize))
@@ -319,8 +319,8 @@ namespace Duplicati.Library.Main.Operation
                 Utility.VerifyParameters(database, m_options);
                 m_blockbuffer = new byte[m_options.Blocksize];
                 
-                var blockhasher = HashAlgorithm.Create(m_options.BlockHashAlgorithm);
-                var filehasher = HashAlgorithm.Create(m_options.FileHashAlgorithm);
+                var blockhasher = (HashAlgorithm)CryptoConfig.CreateFromName(m_options.BlockHashAlgorithm);
+                var filehasher = (HashAlgorithm)CryptoConfig.CreateFromName(m_options.FileHashAlgorithm);
                 if (blockhasher == null)
                     throw new UserInformationException(Strings.Common.InvalidHashAlgorithm(m_options.BlockHashAlgorithm), "BlockHashAlgorithmNotSupported");
                 if (!blockhasher.CanReuseTransform)

--- a/Duplicati/Library/Main/Operation/TestHandler.cs
+++ b/Duplicati/Library/Main/Operation/TestHandler.cs
@@ -202,7 +202,7 @@ namespace Duplicati.Library.Main.Operation
         /// <param name="sample_percent">A value between 0 and 1 that indicates how many blocks are tested in a dblock file</param>
         public static KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>> TestVolumeInternals(LocalTestDatabase db, IRemoteVolume vol, string tf, Options options, double sample_percent)
         {
-            var blockhasher = HashAlgorithm.Create(options.BlockHashAlgorithm);
+            var blockhasher = (HashAlgorithm)CryptoConfig.CreateFromName(options.BlockHashAlgorithm);
  
             if (blockhasher == null)
                 throw new UserInformationException(Strings.Common.InvalidHashAlgorithm(options.BlockHashAlgorithm), "BlockHashAlgorithmInvalid");

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -180,7 +180,7 @@ namespace Duplicati.Library.Main
             {
                 try
                 {
-                    var p = System.Security.Cryptography.HashAlgorithm.Create(h);
+                    var p = (HashAlgorithm)CryptoConfig.CreateFromName(h);
                     if (p != null)
                         r.Add(h);
                 }
@@ -1363,7 +1363,7 @@ namespace Duplicati.Library.Main
             get
             {
 				if (m_cachedBlockHashSize.Key != BlockHashAlgorithm)
-					m_cachedBlockHashSize = new KeyValuePair<string, int>(BlockHashAlgorithm, HashAlgorithm.Create(BlockHashAlgorithm).HashSize / 8);
+					m_cachedBlockHashSize = new KeyValuePair<string, int>(BlockHashAlgorithm, (HashAlgorithm)CryptoConfig.CreateFromName(BlockHashAlgorithm).HashSize / 8);
 				
 				return m_cachedBlockHashSize.Value;
             }

--- a/Duplicati/Library/Main/Utility.cs
+++ b/Duplicati/Library/Main/Utility.cs
@@ -51,7 +51,7 @@ namespace Duplicati.Library.Main
                     
                 using (var ms = new System.IO.MemoryStream())
                 using (var w = new StreamWriter(ms, Encoding.UTF8))
-                using(var filehasher = HashAlgorithm.Create(options.FileHashAlgorithm))
+                using(var filehasher = (HashAlgorithm)CryptoConfig.CreateFromName(options.FileHashAlgorithm))
                 {
                     if (filehasher == null)
                         throw new Duplicati.Library.Interface.UserInformationException(Strings.Common.InvalidHashAlgorithm(options.FileHashAlgorithm), "FileHashAlgorithmNotSupported");

--- a/Duplicati/Library/Utility/HashCalculatingStream.cs
+++ b/Duplicati/Library/Utility/HashCalculatingStream.cs
@@ -30,7 +30,7 @@ namespace Duplicati.Library.Utility
     public class MD5CalculatingStream : HashCalculatingStream
     {
         public MD5CalculatingStream(System.IO.Stream basestream)
-            : base(basestream, "MD5")
+            : base(basestream, MD5.Create())
         {
         }
     }
@@ -48,11 +48,6 @@ namespace Duplicati.Library.Utility
 
         private byte[] m_hashbuffer = null;
         private int m_hashbufferLength = 0;
-
-        public HashCalculatingStream(System.IO.Stream basestream, string hashalgorithm)
-            : this(basestream, HashAlgorithm.Create(hashalgorithm))
-        {
-        }
 
         public HashCalculatingStream(System.IO.Stream basestream, System.Security.Cryptography.HashAlgorithm algorithm)
             : base(basestream)

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -42,11 +42,6 @@ namespace Duplicati.Library.Utility
         private static bool? CachedIsFSCaseSensitive;
 
         /// <summary>
-        /// Gets the hash algorithm used for calculating a hash
-        /// </summary>
-        private static string BlockHashAlgorithm => "SHA256";
-
-        /// <summary>
         /// The EPOCH offset (unix style)
         /// </summary>
         public static readonly DateTime EPOCH = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -586,16 +581,6 @@ namespace Duplicati.Library.Utility
             }
 
             return a1 == a2;
-        }
-
-        /// <summary>
-        /// Calculates the hash of a given stream, and returns the results as an base64 encoded string
-        /// </summary>
-        /// <param name="stream">The stream to calculate the hash for</param>
-        /// <returns>The base64 encoded hash</returns>
-        public static string CalculateHash(Stream stream)
-        {
-            return Convert.ToBase64String(HashAlgorithm.Create(BlockHashAlgorithm).ComputeHash(stream));
         }
 
         /// <summary>
@@ -1308,7 +1293,7 @@ namespace Duplicati.Library.Utility
         {
             // We avoid storing the passphrase directly, 
             // instead we salt and rehash repeatedly
-            using (var h = System.Security.Cryptography.SHA256.Create())
+            using (var h = SHA256.Create())
             {
                 h.Initialize();
                 h.TransformBlock(salt, 0, salt.Length, salt, 0);

--- a/Duplicati/Server/WebServer/RESTMethods/Captcha.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Captcha.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 
 namespace Duplicati.Server.WebServer.RESTMethods
 {
@@ -111,15 +112,10 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
                 var answer = CaptchaUtil.CreateRandomAnswer(minlength: 6, maxlength: 6);
                 var nonce = Guid.NewGuid().ToString();
-
-                string token;
-                using (var ms = new System.IO.MemoryStream())
-                {
-                    var bytes = System.Text.Encoding.UTF8.GetBytes(answer + nonce);
-                    ms.Write(bytes, 0, bytes.Length);
-                    ms.Position = 0;
-                    token = Library.Utility.Utility.Base64PlainToBase64Url(Library.Utility.Utility.CalculateHash(ms));
-                }
+                var bytes = System.Text.Encoding.UTF8.GetBytes(answer + nonce);
+                string token = Library.Utility.Utility.Base64PlainToBase64Url(
+                    Convert.ToBase64String(SHA256.Create().ComputeHash(bytes))
+                );
 
                 lock (m_lock)
                 {

--- a/Duplicati/Server/WebServer/Server.cs
+++ b/Duplicati/Server/WebServer/Server.cs
@@ -135,9 +135,9 @@ namespace Duplicati.Server.WebServer
                 try
                 {
                     if (string.IsNullOrWhiteSpace(certificateFilePassword))
-                        cert = new X509Certificate2(certificateFile, "", X509KeyStorageFlags.Exportable);
+                        cert = new X509Certificate2(certificateFile, "");
                     else
-                        cert = new X509Certificate2(certificateFile, certificateFilePassword, X509KeyStorageFlags.Exportable);
+                        cert = new X509Certificate2(certificateFile, certificateFilePassword);
 
                     certValid = cert.HasPrivateKey;
                 }


### PR DESCRIPTION
Where possible uses of `HashAlgorithm.Create` with a hard-coded string algorithm name parameter just replaced with explicit uses of the available hash classes (e.g. `SHA256.Create()`).  
In places where algorithm name is provided by a parameter, used recommended `CryptoConfig.CreateFromName()`.
Cleaned up a bit of code in a few places and removed rarely used utility code.